### PR TITLE
Fix content inspection on specific files treated as binaries.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,12 +159,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "content_inspector"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "context-generator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "content_inspector",
  "glob",
  "mime_guess",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1.0"
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
+content_inspector = "0.2"
 
 [dev-dependencies]
 tempfile = "3.15"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -90,7 +90,7 @@ pub enum Commands {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```no_run
 /// use context_generator::cli::run_cli;
 ///
 /// // This would typically be called from main()


### PR DESCRIPTION
Some file extensions, such as `.go` would incorrectly be assumed to be binaries.

This uses a better library to perform such detection.